### PR TITLE
Remove those enrichers which add the additional objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>fabric8-maven-plugin</artifactId>
-                <version>3.1.92</version>
+                <version>3.2.1</version>
 
                 <configuration>
                    <!-- <mode>openshift</mode>-->
@@ -388,6 +388,13 @@
                         <password>admin</password>
                         <useOpenShiftAuth>true</useOpenShiftAuth>
                     </authConfig>
+                    <enricher>
+                        <excludes>
+                            <exclude>fmp-image</exclude>
+                            <exclude>fmp-controller</exclude>
+                            <exclude>fmp-service</exclude>
+                        </excludes>
+                    </enricher>
                 </configuration>
 
                 <executions>

--- a/src/main/fabric8/db-dc.yml
+++ b/src/main/fabric8/db-dc.yml
@@ -14,6 +14,7 @@ spec:
     spec:
       containers:
         - name: ${project.artifactId}-db
+          image: ${project.artifactId}-db:${project.version}
           env:
           - name: POSTGRESQL_USER
             value: mjopadmin

--- a/src/main/fabric8/web-dc.yml
+++ b/src/main/fabric8/web-dc.yml
@@ -14,6 +14,7 @@ spec:
     spec:
       containers:
         - name: ${project.artifactId}
+          image: ${project.artifactId}:${project.version}
           env:
           - name: POSTGRESQL_USER
             value: mjopadmin


### PR DESCRIPTION
In one of the next version a profile 'no-padding' or 'no-defaults' or .. (still looking for a good name) will be available so the configuration be done even smaller.

Sorry, for the long roundtrip, sometimes on can't see the wood for the trees ;-)